### PR TITLE
Add /usr/x86_64-w64-mingw32/bin to PATH

### DIFF
--- a/gen_config.sh
+++ b/gen_config.sh
@@ -42,6 +42,8 @@ for atom in $*; do
           exit 2;;
       esac
       sysroot_bin="$("$gcc" -print-sysroot)\\mingw\\bin"
+      eval "bin_$arch=\
+\"\$(cygpath -w \"/usr/\$arch-w64-mingw32/bin\" | sed -e '$opam_escape')\""
       eval "sysroot_$arch=\
 \"\$(cygpath -w \"\$sysroot_bin\" | sed -e '$opam_escape')\""
     else
@@ -59,7 +61,9 @@ fi
 cat > "$package.config" <<EOF
 opam-version: "2.0"
 variables {
+  bin-x86_64: "$bin_x86_64"
   runtime-x86_64: "$sysroot_x86_64"
+  bin-i686: "$bin_i686"
   runtime-i686: "$sysroot_i686"
 }
 EOF

--- a/mingw-w64-shims.opam
+++ b/mingw-w64-shims.opam
@@ -38,6 +38,8 @@ depopts: [
   "conf-pkg-config"
 ]
 setenv: [
+  [ PATH += "%{_:bin-x86_64}%" ]
   [ PATH += "%{_:runtime-x86_64}%" ]
+  [ PATH += "%{_:bin-i686}%" ]
   [ PATH += "%{_:runtime-i686}%" ]
 ]


### PR DESCRIPTION
There are binaries in this path that are necessary for some package builds, e.g. the luv library runs some configure scripts that look for an `ar` executable in PATH, see: https://github.com/aantron/luv/issues/162. This patch allows successfully building such libraries out of the box on Windows.